### PR TITLE
Enforce owner-only access to Evento endpoints and add environment-driven security settings

### DIFF
--- a/agenda/settings.py
+++ b/agenda/settings.py
@@ -21,15 +21,25 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'jpk4q*v63uha26l8b#d*ds8yt6!2g_fcqy(cd(*9)wmp#@vb8@'
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'dev-only-insecure-key-replace-this-with-a-random-secret-key-12345')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-# DEBUG = False             # Produção
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() == 'true'
 
 # ALLOWED_HOSTS = [".herokuapp.com"]
 # ALLOWED_HOSTS = ['*']     # Produção
-ALLOWED_HOSTS = ['127.0.0.1', 'localhost'] 
+ALLOWED_HOSTS = [
+    host.strip() for host in os.environ.get('DJANGO_ALLOWED_HOSTS', '127.0.0.1,localhost').split(',') if host.strip()
+]
+
+SECURE_HSTS_SECONDS = 0 if DEBUG else 31536000
+SECURE_HSTS_INCLUDE_SUBDOMAINS = not DEBUG
+SECURE_HSTS_PRELOAD = not DEBUG
+SECURE_SSL_REDIRECT = not DEBUG
+SESSION_COOKIE_SECURE = not DEBUG
+CSRF_COOKIE_SECURE = not DEBUG
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
 
 # Application definition
 INSTALLED_APPS = [

--- a/app/tests.py
+++ b/app/tests.py
@@ -1,3 +1,50 @@
-from django.test import TestCase
+from datetime import timedelta
 
-# Create your tests here.
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.utils import timezone
+
+from app.models import Evento
+
+
+class EventoSecurityTests(TestCase):
+    def setUp(self):
+        self.owner = User.objects.create_user(username='owner', password='senha12345')
+        self.other_user = User.objects.create_user(username='other', password='senha12345')
+
+        self.owner_event = Evento.objects.create(
+            titulo='Evento privado',
+            descricao='descricao',
+            data_evento=timezone.now() + timedelta(days=1),
+            usuario=self.owner,
+        )
+
+    def test_evento_view_blocks_access_to_other_users_event(self):
+        self.client.login(username='other', password='senha12345')
+
+        response = self.client.get(f'/agenda/evento/?id={self.owner_event.id}')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_json_lista_evento_blocks_access_to_other_users_id(self):
+        self.client.login(username='other', password='senha12345')
+
+        response = self.client.get(f'/agenda/lista/{self.owner.id}/')
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_json_lista_evento_returns_only_authenticated_user_events(self):
+        Evento.objects.create(
+            titulo='Outro evento',
+            descricao='descricao',
+            data_evento=timezone.now() + timedelta(days=1),
+            usuario=self.other_user,
+        )
+        self.client.login(username='other', password='senha12345')
+
+        response = self.client.get(f'/agenda/lista/{self.other_user.id}/')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]['titulo'], 'Outro evento')

--- a/app/views.py
+++ b/app/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
 from django.http.response import Http404, JsonResponse
-from django.shortcuts import render, redirect
+from django.shortcuts import get_object_or_404, render, redirect
 from datetime import datetime as dt
 from django.contrib import messages
 from app.models import Evento
@@ -44,11 +44,11 @@ def lista_eventos(request):
 @login_required(login_url='/login/')
 def evento(request):
     id_evento = request.GET.get('id')
-    
+
     dados = {}
     if id_evento:
-        dados['evento'] = Evento.objects.get(id=id_evento)
-    
+        dados['evento'] = get_object_or_404(Evento, id=id_evento, usuario=request.user)
+
     return render(request, 'evento.html', dados)
 
 
@@ -62,13 +62,11 @@ def submit_evento(request):
 
         id_evento = request.POST.get('id_evento')
         if id_evento:
-            evento = Evento.objects.get(id=id_evento)
-
-            if evento.usuario == usuario:
-                evento.titulo = titulo
-                evento.data_evento = data_evento
-                evento.descricao = descricao
-                evento.save()
+            evento = get_object_or_404(Evento, id=id_evento, usuario=usuario)
+            evento.titulo = titulo
+            evento.data_evento = data_evento
+            evento.descricao = descricao
+            evento.save()
                 
             # Evento.objects.filter(id=id_evento).update(
             #     titulo=titulo, data_evento=data_evento, descricao=descricao)
@@ -80,22 +78,16 @@ def submit_evento(request):
 
 @login_required(login_url='/login/')
 def delete_evento(request, id_evento):
-    usuario = request.user
-    try:
-        evento = Evento.objects.get(id=id_evento)
-    except Exception:
-        raise Http404()
-        
-    if usuario == evento.usuario:
-        evento.delete()
-    else:
-        raise Http404()
-    
+    evento = get_object_or_404(Evento, id=id_evento, usuario=request.user)
+    evento.delete()
+
     return redirect('/')
 
 
-# @login_required(login_url='/login/')
+@login_required(login_url='/login/')
 def json_lista_evento(request, id_usuario):
-    usuario = Evento.objects.get(id=id_usuario).values('')
-    evento = Evento.objects.filter(usuario=usuario).values('id', 'titulo')
+    if request.user.id != id_usuario:
+        raise Http404()
+
+    evento = Evento.objects.filter(usuario=request.user).values('id', 'titulo')
     return JsonResponse(list(evento), safe=False)


### PR DESCRIPTION
### Motivation
- Prevent improper access to `Evento` objects by ensuring only the owning user can view, modify, delete, or list their events. 
- Make sensitive Django settings configurable via environment variables to avoid embedding secrets in source and enable safer production defaults. 
- Enable common security headers and cookie/SSL protections when running in non-debug (production) mode.

### Description
- Updated `agenda/settings.py` to read `SECRET_KEY`, `DEBUG`, and `ALLOWED_HOSTS` from environment variables and to apply HSTS, SSL redirect, secure cookie flags, and basic XSS/content-type protections when `DEBUG` is false. 
- Replaced direct `Evento.objects.get(...)` lookups with `get_object_or_404(...)` that include `usuario=request.user` in `app/views.py` for `evento`, `submit_evento`, and `delete_evento` to enforce ownership checks. 
- Added an ownership check in `json_lista_evento` to ensure the requesting user matches the `id_usuario` and return a 404 otherwise. 
- Added `app/tests.py` with `EventoSecurityTests` covering viewing another user's event (expects 404), JSON list access by other users (expects 404), and JSON list returning only the authenticated user's events.

### Testing
- Added and executed the automated unit tests in `app.tests.EventoSecurityTests` with `python manage.py test app`. 
- All added tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b591d7acc0832db939f5444a55c6c2)